### PR TITLE
feat(swagger): add operations and parameter parsing

### DIFF
--- a/src/swagger/handleJson.test.ts
+++ b/src/swagger/handleJson.test.ts
@@ -27,6 +27,15 @@ const swaggerApiDefinition: OpenAPIV2.Document = {
           "text/html",
         ],
         summary: "Retrieves the collection of Book resources.",
+        parameters: [
+          {
+            name: "page",
+            in: "query",
+            required: false,
+            type: "integer",
+            description: "The collection page number",
+          },
+        ],
         responses: {
           "200": {
             description: "Book collection response",
@@ -1258,5 +1267,49 @@ describe(`Parse Swagger Documentation from Json`, () => {
     );
 
     expect(toBeParsed[1].fields?.[0]).toEqual(parsed[1]?.fields[0]);
+  });
+
+  test(`should create operations and parameters`, () => {
+    expect(toBeParsed[0].operations).toEqual([
+      {
+        name: "Retrieves a Book resource.",
+        type: "show",
+        method: "GET",
+        deprecated: false,
+      },
+      {
+        name: "Replaces the Book resource.",
+        type: "edit",
+        method: "PUT",
+        deprecated: false,
+      },
+      {
+        name: "Removes the Book resource.",
+        type: "delete",
+        method: "DELETE",
+        deprecated: false,
+      },
+      {
+        name: "Retrieves the collection of Book resources.",
+        type: "list",
+        method: "GET",
+        deprecated: false,
+      },
+      {
+        name: "Creates a Book resource.",
+        type: "create",
+        method: "POST",
+        deprecated: false,
+      },
+    ]);
+
+    expect(toBeParsed[0].parameters).toEqual([
+      expect.objectContaining({
+        variable: "page",
+        range: "integer",
+        required: false,
+        description: "The collection page number",
+      }),
+    ]);
   });
 });

--- a/src/swagger/handleJson.ts
+++ b/src/swagger/handleJson.ts
@@ -1,6 +1,9 @@
 import inflection from "inflection";
 import type { OpenAPIV2 } from "openapi-types";
 import { Field } from "../Field.js";
+import { Operation } from "../Operation.js";
+import type { OperationType } from "../Operation.js";
+import { Parameter } from "../Parameter.js";
 import getType from "../openapi3/getType.js";
 import { Resource } from "../Resource.js";
 import getResourcePaths from "../utils/getResources.js";
@@ -12,13 +15,26 @@ export function removeTrailingSlash(url: string): string {
   return url;
 }
 
+function buildOperationFromPathItem(
+  httpMethod: `${OpenAPIV2.HttpMethods}`,
+  operationType: OperationType,
+  pathItem: OpenAPIV2.OperationObject,
+): Operation {
+  return new Operation(pathItem.summary || operationType, operationType, {
+    method: httpMethod.toUpperCase(),
+    deprecated: !!pathItem.deprecated,
+  });
+}
+
 export default function handleJson(
   response: OpenAPIV2.Document,
   entrypointUrl: string,
 ): Resource[] {
   const paths = getResourcePaths(response.paths);
 
-  return paths.map((path) => {
+  const resources: Resource[] = [];
+
+  for (const path of paths) {
     const splittedPath = removeTrailingSlash(path).split("/");
     const baseName = splittedPath[splittedPath.length - 2];
     if (!baseName) {
@@ -74,13 +90,62 @@ export default function handleJson(
         }),
     );
 
-    return new Resource(name, url, {
+    const resource = new Resource(name, url, {
       id: null,
       title,
       description,
       fields,
       readableFields: fields,
       writableFields: fields,
+      parameters: [],
+      // oxlint-disable-next-line prefer-await-to-then
+      getParameters: () => Promise.resolve([]),
     });
-  });
+
+    const pathItem = response.paths[path];
+    const showOperation = pathItem.get;
+    const putOperation = pathItem.put;
+    const patchOperation = pathItem.patch;
+    const deleteOperation = pathItem.delete;
+    const pathCollection = response.paths[`/${name}`];
+    const listOperation = pathCollection && pathCollection.get;
+    const createOperation = pathCollection && pathCollection.post;
+    resource.operations = [
+      ...(showOperation
+        ? [buildOperationFromPathItem("get", "show", showOperation)]
+        : []),
+      ...(putOperation
+        ? [buildOperationFromPathItem("put", "edit", putOperation)]
+        : []),
+      ...(patchOperation
+        ? [buildOperationFromPathItem("patch", "edit", patchOperation)]
+        : []),
+      ...(deleteOperation
+        ? [buildOperationFromPathItem("delete", "delete", deleteOperation)]
+        : []),
+      ...(listOperation
+        ? [buildOperationFromPathItem("get", "list", listOperation)]
+        : []),
+      ...(createOperation
+        ? [buildOperationFromPathItem("post", "create", createOperation)]
+        : []),
+    ];
+
+    if (listOperation && listOperation.parameters) {
+      resource.parameters = listOperation.parameters.map(
+        (parameter) =>
+          new Parameter(
+            parameter.name,
+            parameter.type ? getType(parameter.type, parameter.format) : null,
+            parameter.required || false,
+            parameter.description || "",
+            parameter.deprecated,
+          ),
+      );
+    }
+
+    resources.push(resource);
+  }
+
+  return resources;
 }


### PR DESCRIPTION
## Summary
- revert OpenAPI 3 handler parameter type logic
- parse Swagger item and collection operations
- map Swagger collection parameters using `type`/`format`

## Testing
- `pnpm vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68af8d6ba1688322913b42ed968a4441